### PR TITLE
Add extra buttons for heavy task and data fetch placeholder

### DIFF
--- a/src/fetchPlaceholder.ts
+++ b/src/fetchPlaceholder.ts
@@ -1,0 +1,6 @@
+export function setupFetchPlaceholder(element: HTMLButtonElement) {
+  element.innerHTML = 'Fetch data (TODO)';
+  element.addEventListener('click', () => {
+    element.innerHTML = 'Fetching... (not implemented)';
+  });
+}

--- a/src/heavyTask.ts
+++ b/src/heavyTask.ts
@@ -1,0 +1,10 @@
+export function setupHeavyTask(element: HTMLButtonElement) {
+  element.innerHTML = 'Compute sum';
+  element.addEventListener('click', () => {
+    let sum = 0;
+    for (let i = 1; i <= 100000; i++) {
+      sum += i;
+    }
+    element.innerHTML = `sum is ${sum}`;
+  });
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,8 @@ import './style.css'
 import typescriptLogo from './typescript.svg'
 import viteLogo from '/vite.svg'
 import { setupCounter } from './counter.ts'
+import { setupHeavyTask } from './heavyTask.ts'
+import { setupFetchPlaceholder } from './fetchPlaceholder.ts'
 
 document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
   <div>
@@ -14,6 +16,8 @@ document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
     <h1>Vite + TypeScript</h1>
     <div class="card">
       <button id="counter" type="button"></button>
+      <button id="heavy" type="button"></button>
+      <button id="fetch" type="button"></button>
     </div>
     <p class="read-the-docs">
       Click on the Vite and TypeScript logos to learn more
@@ -22,3 +26,5 @@ document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
 `
 
 setupCounter(document.querySelector<HTMLButtonElement>('#counter')!)
+setupHeavyTask(document.querySelector<HTMLButtonElement>('#heavy')!)
+setupFetchPlaceholder(document.querySelector<HTMLButtonElement>('#fetch')!)


### PR DESCRIPTION
## Summary
- introduce a heavy computation button that sums 1..100000
- add a placeholder button for future data fetching
- extend main UI to render the new buttons

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68402bfeb0bc832f8527dc9c95f0ee66