### PR TITLE
Fix service worker scope

### DIFF
--- a/public/graphql-sw.js
+++ b/public/graphql-sw.js
@@ -4,14 +4,22 @@ import { request } from 'graffle'
 
 const endpoint = 'https://beta.pokeapi.co/graphql/v1beta'
 
-self.addEventListener('message', (event: any) => {
+self.addEventListener('install', () => {
+  self.skipWaiting()
+})
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim())
+})
+
+self.addEventListener('message', (event) => {
   const data = event.data
   console.log('[sw] message received', data)
   if (!data || data.type !== 'GRAPHQL_FETCH') return
   event.waitUntil(handleGraphQL(event))
 })
 
-async function handleGraphQL(event: ExtendableMessageEvent) {
+async function handleGraphQL(event) {
   const { query, variables } = event.data
   console.log('[sw] handleGraphQL', { query, variables })
   try {

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,8 +6,10 @@ import { setupFetchPokemons } from './fetchPokemons.ts'
 if ('serviceWorker' in navigator) {
   try {
     const registration = await navigator.serviceWorker.register(
-      new URL('./graphql-sw.ts', import.meta.url),
-      { type: 'module' },
+      '/graphql-sw.js',
+      {
+        type: 'module',
+      },
     )
     if (registration.installing) {
           console.log("Service worker installing");


### PR DESCRIPTION
## Summary
- move service worker script under `public/` so the page is under its scope
- update registration path

## Testing
- `npm run build` *(fails: Top-level await is not available)*

------
https://chatgpt.com/codex/tasks/task_e_68405cfdecb8832f9c2f0670647a2c53