### PR TITLE
Fix service worker import and build

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -4,24 +4,28 @@ import { setupHeavyTask } from './heavyTask.ts'
 import { setupFetchPokemons } from './fetchPokemons.ts'
 
 if ('serviceWorker' in navigator) {
-  try {
-    const registration = await navigator.serviceWorker.register(
-      new URL('./graphql-sw.ts', import.meta.url),
-      { type: 'module' },
-    )
-    if (registration.installing) {
-          console.log("Service worker installing");
-        } else if (registration.waiting) {
-          console.log("Service worker installed");
-        } else if (registration.active) {
-          console.log("Service worker active");
-        }
-    navigator.serviceWorker.ready.then((r) => {
-      console.log('Service worker ready', r.active)
-    })
-  } catch (error) {
-    console.error(`Registration failed with ${error}`);
-  }
+  (async () => {
+    try {
+      const registration = await navigator.serviceWorker.register(
+        '/graphql-sw.js',
+        {
+          type: 'module',
+        },
+      )
+      if (registration.installing) {
+            console.log("Service worker installing");
+          } else if (registration.waiting) {
+            console.log("Service worker installed");
+          } else if (registration.active) {
+            console.log("Service worker active");
+          }
+      navigator.serviceWorker.ready.then((r) => {
+        console.log('Service worker ready', r.active)
+      })
+    } catch (error) {
+      console.error(`Registration failed with ${error}`);
+    }
+  })()
 }
 
 document.querySelector<HTMLDivElement>('#app')!.innerHTML = `

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "useDefineForClassFields": true,
     "module": "ESNext",
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "skipLibCheck": true,
 
     /* Bundler mode */


### PR DESCRIPTION
## Summary
- rewrite service worker to use `fetch` instead of importing `graffle`
- wrap service worker registration in an async IIFE
- compile TypeScript for ES2022 so top-level await works during dev

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68405cfdecb8832f9c2f0670647a2c53