### PR TITLE
Add cache-based data transfer

### DIFF
--- a/src/fetchPokemons.worker.ts
+++ b/src/fetchPokemons.worker.ts
@@ -68,8 +68,12 @@ self.onmessage = async () => {
       url: endpoint,
       document: query,
     })
-    console.log('Worker: posting fetched data')
-    self.postMessage({ data })
+    const key = `pokemon-${Date.now()}`
+    console.log('Worker: caching fetched data with key', key)
+    const cache = await caches.open('graphql-cache')
+    await cache.put(key, new Response(JSON.stringify(data)))
+    console.log('Worker: posting cache key to main thread')
+    self.postMessage({ key })
   } catch (err) {
     console.error('Worker: error fetching data', err)
     self.postMessage({ error: (err as Error).message })


### PR DESCRIPTION
## Summary
- save heavy GraphQL query results into the Cache API inside the worker
- send cache key to the main thread and read the cached data there
- log each step of the caching process

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6846c761a014832f85a6fd7c1bb005f0