### PR TITLE
Fix cache key path

### DIFF
--- a/src/fetchPokemons.ts
+++ b/src/fetchPokemons.ts
@@ -69,7 +69,7 @@ export function setupFetchPokemons(
       }
       console.log('Main thread: reading data from cache with key', key)
       const cache = await caches.open('graphql-cache')
-      const response = await cache.match(key)
+      const response = await cache.match(`/${key}`)
       if (!response) {
         output.textContent = 'Error reading cached data'
         console.error('Main thread: cache miss')

--- a/src/fetchPokemons.worker.ts
+++ b/src/fetchPokemons.worker.ts
@@ -71,7 +71,7 @@ self.onmessage = async () => {
     const key = `pokemon-${Date.now()}`
     console.log('Worker: caching fetched data with key', key)
     const cache = await caches.open('graphql-cache')
-    await cache.put(key, new Response(JSON.stringify(data)))
+    await cache.put(`/${key}`, new Response(JSON.stringify(data)))
     console.log('Worker: posting cache key to main thread')
     self.postMessage({ key })
   } catch (err) {


### PR DESCRIPTION
## Summary
- ensure both fetch worker and main thread use absolute cache key paths

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6846e7b41790832fb1c0926613aaf7e1