### PR TITLE
Use IndexedDB instead of Cache API

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -1,0 +1,40 @@
+const DB_NAME = 'graphql-db';
+const STORE_NAME = 'responses';
+const DB_VERSION = 1;
+
+function open(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: 'key' });
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+export async function storeData(key: string, data: unknown): Promise<void> {
+  const db = await open();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    tx.objectStore(STORE_NAME).put({ key, data });
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+export async function readData<T>(key: string): Promise<T | undefined> {
+  const db = await open();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const request = tx.objectStore(STORE_NAME).get(key);
+    request.onsuccess = () => {
+      const result = request.result as { key: string; data: T } | undefined;
+      resolve(result?.data);
+    };
+    request.onerror = () => reject(request.error);
+  });
+}

--- a/src/fetchPokemons.ts
+++ b/src/fetchPokemons.ts
@@ -1,3 +1,5 @@
+import { readData } from './db'
+
 const worker = new Worker(new URL('./fetchPokemons.worker.ts', import.meta.url), {
   type: 'module',
 })
@@ -67,17 +69,15 @@ export function setupFetchPokemons(
         console.timeEnd('fetchPokemons')
         return
       }
-      console.log('Main thread: reading data from cache with key', key)
-      const cache = await caches.open('graphql-cache')
-      const response = await cache.match(`/${key}`)
-      if (!response) {
-        output.textContent = 'Error reading cached data'
-        console.error('Main thread: cache miss')
+      console.log('Main thread: reading data from DB with key', key)
+      const data = await readData<QueryResult>(key)
+      if (!data) {
+        output.textContent = 'Error reading stored data'
+        console.error('Main thread: data not found')
         console.timeEnd('fetchPokemons')
         return
       }
-      const data = (await response.json()) as QueryResult
-      console.log('Main thread: data read from cache')
+      console.log('Main thread: data read from DB')
       console.timeEnd('fetchPokemons')
       species = data.gen3_species
       total = species.length

--- a/src/fetchPokemons.worker.ts
+++ b/src/fetchPokemons.worker.ts
@@ -1,6 +1,6 @@
 /// <reference lib="webworker" />
 
-declare const caches: CacheStorage;
+import { storeData } from './db'
 
 import { ApolloClient, InMemoryCache, gql } from '@apollo/client/core'
 import { createHttpLink } from '@apollo/client/link/http'
@@ -76,9 +76,8 @@ self.onmessage = async () => {
       query,
     })
     const key = `pokemon-${Date.now()}`
-    console.log('Worker: caching fetched data with key', key)
-    const cache = await caches.open('graphql-cache')
-    await cache.put(`/${key}`, new Response(JSON.stringify(data)))
+    console.log('Worker: storing fetched data with key', key)
+    await storeData(key, data)
     console.log('Worker: posting cache key to main thread')
     self.postMessage({ key })
   } catch (err) {


### PR DESCRIPTION
## Summary
- implement small IndexedDB helper
- store fetched GraphQL results in IndexedDB from the worker
- read stored results in the main thread instead of using Cache API

## Testing
- `npm run build`
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6852d8d91b18832fa55b801e6d1310db